### PR TITLE
1 private llm providers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import {
 import { BrowserConsole } from "./BrowserConsole";
 import { PureChatLLMChat } from "./Chat";
 import { codelanguages } from "./codelanguages";
-import { AskForAPI, CodeAreaComponent, EditWand } from "./models";
+import { AskForAPI, CodeAreaComponent, EditModalProviders, EditWand } from "./models";
 import { EmptyApiKey, version } from "./s.json";
 import { StatSett } from "./settings";
 import { PureChatLLMSideView } from "./SideView";
@@ -628,6 +628,19 @@ class PureChatLLMSettingTab extends PluginSettingTab {
 
     new Setting(containerEl).setName("Advanced").setHeading();
     new Setting(containerEl)
+      .setName("Custom LLM Providers")
+      .setDesc(
+        "Add custom LLM providers with API keys. These will be available in the model provider dropdown."
+      )
+      .addButton((btn) =>
+        btn
+          .setButtonText("Add custom provider")
+          .setCta()
+          .onClick(() => {
+            new EditModalProviders(this.app, this.plugin).open();
+          })
+      );
+    new Setting(containerEl)
       .setName("Autogenerate title")
       .setDesc(
         "How many responses to wait for before automatically creating a conversation title (set to 0 to disable)."
@@ -646,7 +659,6 @@ class PureChatLLMSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           })
       );
-
     new Setting(containerEl)
       .setName("Auto reverse roles")
       .setDesc("Automatically switch roles when the last message is empty, for replying to self.")

--- a/src/models.ts
+++ b/src/models.ts
@@ -304,6 +304,15 @@ const endpointDescriptions: PureChatLLMAPI = {
   getapiKey: "Optional URL the API key page for the provider.",
 };
 
+const endpointInputPlaceholders: PureChatLLMAPI = {
+  name: "Enter the name of the LLM provider...",
+  apiKey: "Enter your API key...",
+  endpoint: "https://api.example.com/v1/chat/completions",
+  defaultmodel: "gpt-3.5-turbo",
+  listmodels: "https://api.example.com/v1/models (Optional)",
+  getapiKey: "https://example.com/get-api-key (Optional)",
+};
+
 export class EditModalProviders extends Modal {
   plugin: PureChatLLM;
   app: App;
@@ -351,7 +360,7 @@ export class EditModalProviders extends Modal {
         .setTooltip("Add a new endpoint")
         .onClick(() => {
           this.plugin.settings.endpoints.push({
-            name: "New Endpoint",
+            name: "",
             apiKey: "",
             endpoint: "",
             defaultmodel: "",
@@ -370,7 +379,7 @@ export class EditModalProviders extends Modal {
         .setDesc(endpointDescriptions[key as keyof PureChatLLMAPI])
         .addText((text) => {
           text
-            .setPlaceholder(selectedEndpoint[key as keyof PureChatLLMAPI] || "")
+            .setPlaceholder(endpointInputPlaceholders[key as keyof PureChatLLMAPI])
             .setValue(selectedEndpoint[key as keyof PureChatLLMAPI])
             .onChange((value) => {
               selectedEndpoint[key as keyof PureChatLLMAPI] = value.trim();
@@ -381,6 +390,8 @@ export class EditModalProviders extends Modal {
     this.setTitle(selectedEndpoint.name);
   }
   onClose(): void {
+    const { settings } = this.plugin;
+    settings.endpoints = settings.endpoints.filter((endpoint) => endpoint.name);
     this.plugin.saveSettings();
     super.onClose();
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -58,6 +58,14 @@ export const StatSett = {
       listmodels: "https://api.deepseek.com/v1/models",
       getapiKey: "https://platform.deepseek.com/api_keys",
     },
+    {
+      name: "Olama",
+      apiKey: "ollama",
+      endpoint: "http://localhost:11434/v1/chat/completions",
+      defaultmodel: "qwen3:0.6b",
+      listmodels: "http://localhost:11434/v1/models",
+      getapiKey: "",
+    },
   ],
   chatParser: [
     {


### PR DESCRIPTION
This pull request introduces significant enhancements to the `PureChatLLM` plugin, focusing on enabling support for custom LLM providers. The changes include the addition of a new modal for managing LLM providers, updates to the settings interface, and predefined configurations for a new provider. These updates aim to improve flexibility and user experience.

### Support for Custom LLM Providers:
* **New `EditModalProviders` modal**: Added a modal in `src/models.ts` for managing custom LLM providers. Users can add, edit, and remove endpoints, with support for detailed input fields like API key, endpoint URL, and default model.
* **Settings interface update**: Enhanced the `PureChatLLMSettingTab` in `src/main.ts` to include a button for opening the `EditModalProviders` modal, allowing users to manage custom providers directly from the settings.

### Predefined Provider Configuration:
* **Added "Olama" provider**: Included a predefined configuration for the "Olama" provider in `src/settings.ts`, with details such as API key, endpoint URL, and default model.

### Code Structure Updates:
* **Import adjustments**: Updated imports in `src/main.ts` and `src/models.ts` to include `EditModalProviders` and `PureChatLLMAPI`, respectively, ensuring proper integration of new features. [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL24-R24) [[2]](diffhunk://#diff-41b76dc43070308a3e3f270eb861b65259fd377aef32fe30e32ef61b07d086f6R13)