### PR TITLE
Auto detect model provider from model

### DIFF
--- a/src/SideView.ts
+++ b/src/SideView.ts
@@ -9,7 +9,6 @@ import {
   ItemView,
   MarkdownRenderer,
   MarkdownView,
-  Menu,
   Notice,
   Platform,
   Setting,
@@ -130,6 +129,8 @@ export class PureChatLLMSideView extends ItemView {
     }
     new PureChatLLMChat(this.plugin).getAllModels().then((models) => {
       this.plugin.modellist = models;
+      this.plugin.settings.ModelsOnEndpoint[endpoint.name] = models;
+      this.plugin.saveSettings();
       new modelChooser(this.app, this.plugin.modellist, (model) =>
         editor.setValue(
           new PureChatLLMChat(this.plugin).setMarkdown(editor.getValue()).setModel(model).Markdown
@@ -180,6 +181,9 @@ export class PureChatLLMSideView extends ItemView {
       this.defaultContent();
       return;
     }
+    const index =
+      (this.plugin.settings.endpoints.findIndex((e) => e.name === chat.endpoint.name) + 1 || 1) - 1;
+
     container.createDiv({ text: "" }, (contain) => {
       contain.addClass("PURE", "floattop");
       new ButtonComponent(contain)
@@ -193,14 +197,14 @@ export class PureChatLLMSideView extends ItemView {
         .addOptions(
           Object.fromEntries(this.plugin.settings.endpoints.map((e, i) => [i.toString(), e.name]))
         )
-        .setValue(this.plugin.settings.endpoint.toString())
+        .setValue(index.toString())
         .onChange(async (value) => {
           this.plugin.settings.endpoint = parseInt(value, 10);
+          const endpoint = this.plugin.settings.endpoints[this.plugin.settings.endpoint];
           editor.setValue(
             new PureChatLLMChat(this.plugin)
               .setMarkdown(editor.getValue())
-              .setModel(this.plugin.settings.endpoints[this.plugin.settings.endpoint].defaultmodel)
-              .Markdown
+              .setModel(endpoint.defaultmodel).Markdown
           );
           this.plugin.modellist = [];
           await this.plugin.saveSettings();

--- a/src/main.ts
+++ b/src/main.ts
@@ -187,6 +187,7 @@ export default class PureChatLLM extends Plugin {
             const selected = e.getSelection();
             if (checking) return !!selected;
             new PureChatLLMChat(this)
+              .setMarkdown(e.getValue())
               .SelectionResponse(template, selected, addfiletocontext ? e.getValue() : undefined)
               .then((response) => e.replaceSelection(response.content));
           },
@@ -325,6 +326,7 @@ export default class PureChatLLM extends Plugin {
       (s) =>
         s
           ? new PureChatLLMChat(this)
+              .setMarkdown(editor.getValue())
               .SelectionResponse(
                 s,
                 selected,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,7 +13,7 @@ export const StatSett = {
     {
       name: "Gemini",
       apiKey: EmptyApiKey,
-      defaultmodel: "gemini-2.0-flash-lite",
+      defaultmodel: "models/gemini-2.0-flash-lite",
       endpoint: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
       listmodels: "https://generativelanguage.googleapis.com/v1beta/openai/models",
       getapiKey: "https://aistudio.google.com/apikey",

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface PureChatLLMSettings {
   addfiletocontext: boolean;
   CMDselectionTemplates: { [key: string]: boolean };
   CMDchatTemplates: { [key: string]: boolean };
+  ModelsOnEndpoint: { [key: string]: string[] };
 }
 
 export const DEFAULT_SETTINGS: PureChatLLMSettings = {
@@ -29,6 +30,7 @@ export const DEFAULT_SETTINGS: PureChatLLMSettings = {
   addfiletocontext: false,
   CMDselectionTemplates: {},
   CMDchatTemplates: {},
+  ModelsOnEndpoint: {},
 };
 
 export interface PureChatLLMAPI {


### PR DESCRIPTION
Automatically switch the model provider when changing chats to prevent errors. This update introduces a method to detect the appropriate endpoint based on the selected model and ensures that the model is added to the endpoint's model list if not already present.

Fixes #3